### PR TITLE
Add interactive map viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# cities
+# Cities Map
+
+This project displays Russian cities from `city.csv` on an interactive map.
+
+## Usage
+
+1. Start a simple web server:
+   ```bash
+   python3 -m http.server
+   ```
+   and open `http://localhost:8000/index.html` in your browser.
+
+2. The map will show blue circles for every city in the CSV. Hover over a circle
+to see the available information.
+
+The CSV is loaded dynamically, so you can replace `city.csv` with your own data
+without changing the code.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Russian Cities Map</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <style>
+    html, body, #map {
+      height: 100%;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://d3js.org/d3.v7.min.js"></script>
+  <script src="map.js"></script>
+</body>
+</html>

--- a/map.js
+++ b/map.js
@@ -1,0 +1,38 @@
+const map = L.map('map').setView([60, 90], 3);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  maxZoom: 19,
+  attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+// guess possible coordinate column names
+const latKeys = ['lat', 'latitude', 'y'];
+const lonKeys = ['lon', 'lng', 'longitude', 'x'];
+
+function findCoord(row, keys) {
+  for (const k of keys) {
+    if (row[k]) return parseFloat(row[k]);
+  }
+  return undefined;
+}
+
+function rowToTooltip(row) {
+  return Object.entries(row)
+    .map(([k, v]) => `<strong>${k}</strong>: ${v}`)
+    .join('<br/>');
+}
+
+d3.csv('city.csv').then(data => {
+  data.forEach(row => {
+    const lat = findCoord(row, latKeys);
+    const lon = findCoord(row, lonKeys);
+    if (!isNaN(lat) && !isNaN(lon)) {
+      const marker = L.circleMarker([lat, lon], {
+        radius: 4,
+        color: 'blue',
+        fillColor: 'blue',
+        fillOpacity: 0.7
+      }).addTo(map);
+      marker.bindTooltip(rowToTooltip(row), {direction: 'top', sticky: true});
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- provide an HTML page that visualizes `city.csv` on an interactive Leaflet map
- load city data dynamically and show info on hover
- add usage instructions in README

## Testing
- `pytest -q`
- `black --check .`


------
https://chatgpt.com/codex/tasks/task_e_684be93b4c88832a9544e3c9a604800a