### PR TITLE
Add population filtering and simplified tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
   </style>
 </head>
 <body>
+  <div id="controls" style="position:absolute;top:10px;left:10px;z-index:1000;background:white;padding:4px;font-size:14px;">
+    <label>Min population: <input type="number" id="min-pop" value="0" style="width:80px;"></label>
+    <label>Max population: <input type="number" id="max-pop" style="width:80px;"></label>
+  </div>
   <div id="map"></div>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://d3js.org/d3.v7.min.js"></script>

--- a/map.js
+++ b/map.js
@@ -16,9 +16,32 @@ function findCoord(row, keys) {
 }
 
 function rowToTooltip(row) {
-  return Object.entries(row)
-    .map(([k, v]) => `<strong>${k}</strong>: ${v}`)
-    .join('<br/>');
+  const region = row.region || '';
+  const city = row.city || '';
+  const pop = row.population || '';
+  return `<strong>region</strong>: ${region}<br/>` +
+         `<strong>city</strong>: ${city}<br/>` +
+         `<strong>population</strong>: ${pop}`;
+}
+
+const entries = [];
+
+function applyFilter() {
+  const minVal = parseInt(document.getElementById('min-pop').value) || 0;
+  const maxInput = document.getElementById('max-pop').value;
+  const maxVal = maxInput === '' ? Infinity : parseInt(maxInput);
+  entries.forEach(e => {
+    const pop = parseInt(e.row.population) || 0;
+    if (pop >= minVal && pop <= maxVal) {
+      if (!map.hasLayer(e.marker)) {
+        e.marker.addTo(map);
+      }
+    } else {
+      if (map.hasLayer(e.marker)) {
+        map.removeLayer(e.marker);
+      }
+    }
+  });
 }
 
 d3.csv('city.csv').then(data => {
@@ -31,8 +54,12 @@ d3.csv('city.csv').then(data => {
         color: 'blue',
         fillColor: 'blue',
         fillOpacity: 0.7
-      }).addTo(map);
+      });
       marker.bindTooltip(rowToTooltip(row), {direction: 'top', sticky: true});
+      entries.push({marker, row});
     }
   });
+  applyFilter();
+  document.getElementById('min-pop').addEventListener('input', applyFilter);
+  document.getElementById('max-pop').addEventListener('input', applyFilter);
 });


### PR DESCRIPTION
## Summary
- show only `region`, `city`, and `population` in tooltips
- add input controls for min and max population
- filter markers by population based on inputs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bf4b74264832a818b69a7d455e218